### PR TITLE
Fix discovery routes

### DIFF
--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/Constants.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/Constants.java
@@ -2,14 +2,17 @@ package ca.concordia.encs.citydata.core;
 
 /***
  * This is the interface for the storing all constants
+ * 
  * @Author: Rushin Makwana
  * @Date: 7th Feb 2024
  */
 
-
 public interface Constants {
-    public static final String PRODUCER_ROOT_PACKAGE = "ca/concordia/encs/citydata/producers";
+	public static final String SOURCE_CODE_ROOT_PATH = "./src/main/java/";
 
-    public static final String OPERATION_ROOT_PACKAGE= "ca/concordia/encs/citydata/operations";
+	public static final String PRODUCER_ROOT_PACKAGE = SOURCE_CODE_ROOT_PATH + "ca/concordia/encs/citydata/producers/";
+
+	public static final String OPERATION_ROOT_PACKAGE = SOURCE_CODE_ROOT_PATH
+			+ "ca/concordia/encs/citydata/operations/";
 
 }

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/ListOperationsController.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/ListOperationsController.java
@@ -1,17 +1,18 @@
 package ca.concordia.encs.citydata.core;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Field;
-import java.net.URL;
+import java.lang.reflect.Modifier;
+import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 
 /* This java class is to print all available operations and their characteristics 
  * Author: Sikandar Ejaz
@@ -22,52 +23,60 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/operations")
 public class ListOperationsController {
 
-
 	@GetMapping("/list")
-	public List<Map<String, String>> listOperations() throws IOException, ClassNotFoundException {
-		List<Map<String, String>> operationDetailsList = new ArrayList<>();
-
+	public String listOperations() {
+		JsonArray operationDetailsList = new JsonArray();
 		// Get the path to the package
-		URL packageURL = Thread.currentThread().getContextClassLoader().getResource(Constants.OPERATION_ROOT_PACKAGE);
+		String projectRootPath = Paths.get("").toAbsolutePath().toString() + "/";
+		String packagePath = projectRootPath + Constants.OPERATION_ROOT_PACKAGE;
 
-		if (packageURL == null) {
-			return List.of(Map.of("error", "Package not found."));
-		}
+		try {
+			// Scan for class files in the package directory
+			String fileExtension = ".java";
+			File[] files = new File(packagePath).listFiles((dir, name) -> name.endsWith(fileExtension));
 
-		// Scan for class files in the package directory
-		File[] files = new File(packageURL.getFile()).listFiles((dir, name) -> name.endsWith(".class"));
+			if (files != null) {
+				for (File file : files) {
+					// Remove .class extension
+					String className = file.getName().replace(fileExtension, "");
 
-		if (files != null) {
-			for (File file : files) {
-				// Remove .class extension
-				String className = file.getName().substring(0, file.getName().length() - 6);
+					// Load the class using reflection
+					Class<?> clazz = Class.forName("ca.concordia.encs.citydata.operations." + className);
 
-				// Load the class using reflection
-				Class<?> clazz = Class.forName("ca.concordia.encs.citydata.operations." + className);
+					// Map to hold operation details
+					JsonObject operationDetails = new JsonObject();
 
-				// Map to hold operation details
-				Map<String, String> operationDetails = new HashMap<>();
+					// Set class name
+					operationDetails.addProperty("name", clazz.getName());
 
-				// Set class name
-				operationDetails.put("name", clazz.getName());
+					// Collect fields and method signatures
+					List<String> paramList = new ArrayList<>();
 
-				// Collect fields and method signatures
-				List<String> paramList = new ArrayList<>();
+					// List fields
+					Field[] fields = clazz.getDeclaredFields();
+					for (Field field : fields) {
+						int fieldModifiers = field.getModifiers();
+						if (Modifier.isPublic(fieldModifiers)) {
+							paramList.add(field.getName() + " (" + field.getType().getSimpleName() + ")");
+						}
+					}
 
-				// List fields
-				Field[] fields = clazz.getDeclaredFields();
-				for (Field field : fields) {
-					paramList.add(field.getName() + " (" + field.getType().getSimpleName() + ")");
+					operationDetails.addProperty("params", String.join(", ", paramList));
+					operationDetailsList.add(operationDetails);
 				}
-
-				operationDetails.put("params", String.join(", ", paramList));
-
-				operationDetailsList.add(operationDetails);
+			} else {
+				JsonObject errorObject = new JsonObject();
+				errorObject.addProperty("error", "No files found in " + packagePath);
+				operationDetailsList.add(errorObject);
 			}
+
+		} catch (ClassNotFoundException e) {
+			JsonObject errorObject = new JsonObject();
+			errorObject.addProperty("error", e.getMessage());
+			operationDetailsList.add(errorObject);
 		}
 
-		return operationDetailsList.isEmpty()
-				? List.of(Map.of("message", "No operations found in package: " + Constants.OPERATION_ROOT_PACKAGE))
-				: operationDetailsList;
+		return operationDetailsList.toString();
+
 	}
 }

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/ListOperationsController.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/ListOperationsController.java
@@ -1,10 +1,8 @@
 package ca.concordia.encs.citydata.core;
 
 import java.io.File;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
+import java.lang.reflect.Method;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -49,18 +47,9 @@ public class ListOperationsController {
 					// Set class name
 					operationDetails.addProperty("name", clazz.getName());
 
-					// Collect fields and method signatures
-					List<String> paramList = new ArrayList<>();
-
-					// List fields
-					Field[] fields = clazz.getDeclaredFields();
-					for (Field field : fields) {
-						int fieldModifiers = field.getModifiers();
-						if (Modifier.isPublic(fieldModifiers)) {
-							paramList.add(field.getName() + " (" + field.getType().getSimpleName() + ")");
-						}
-					}
-
+					// List setter methods, which correspond to user-accessible params
+					Method[] methods = clazz.getMethods();
+					List<String> paramList = StringUtils.getParamDescriptions(methods);
 					operationDetails.addProperty("params", String.join(", ", paramList));
 					operationDetailsList.add(operationDetails);
 				}

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/ListProducerController.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/ListProducerController.java
@@ -1,17 +1,18 @@
 package ca.concordia.encs.citydata.core;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Field;
-import java.net.URL;
+import java.lang.reflect.Modifier;
+import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 
 /* This java class is to print all available producers and their characteristics
  * Author: Sikandar Ejaz
@@ -22,52 +23,60 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/producers")
 public class ListProducerController {
 
-
 	@GetMapping("/list")
-	public List<Map<String, String>> listProducers() throws IOException, ClassNotFoundException {
-		List<Map<String, String>> producersDetailsList = new ArrayList<>();
-
+	public String listProducers() {
+		JsonArray producerDetailsList = new JsonArray();
 		// Get the path to the package
-		URL packageURL = Thread.currentThread().getContextClassLoader().getResource(Constants.PRODUCER_ROOT_PACKAGE);
+		String projectRootPath = Paths.get("").toAbsolutePath().toString() + "/";
+		String packagePath = projectRootPath + Constants.PRODUCER_ROOT_PACKAGE;
 
-		if (packageURL == null) {
-			return List.of(Map.of("error", "Package not found."));
-		}
+		try {
+			// Scan for class files in the package directory
+			String fileExtension = ".java";
+			File[] files = new File(packagePath).listFiles((dir, name) -> name.endsWith(fileExtension));
 
-		// Scan for class files in the package directory
-		File[] files = new File(packageURL.getFile()).listFiles((dir, name) -> name.endsWith(".class"));
+			if (files != null) {
+				for (File file : files) {
+					// Remove .class extension
+					String className = file.getName().replace(fileExtension, "");
 
-		if (files != null) {
-			for (File file : files) {
-				// Remove .class extension
-				String className = file.getName().substring(0, file.getName().length() - 6);
+					// Load the class using reflection
+					Class<?> clazz = Class.forName("ca.concordia.encs.citydata.producers." + className);
 
-				// Load the class using reflection
-				Class<?> clazz = Class.forName("ca.concordia.encs.citydata.producers." + className);
+					// Map to hold operation details
+					JsonObject operationDetails = new JsonObject();
 
-				// Map to hold operation details
-				Map<String, String> producersDetails = new HashMap<>();
+					// Set class name
+					operationDetails.addProperty("name", clazz.getName());
 
-				// Set class name
-				producersDetails.put("name", clazz.getName());
+					// Collect fields and method signatures
+					List<String> paramList = new ArrayList<>();
 
-				// Collect fields and method signatures
-				List<String> paramList = new ArrayList<>();
+					// List fields
+					Field[] fields = clazz.getDeclaredFields();
+					for (Field field : fields) {
+						int fieldModifiers = field.getModifiers();
+						if (Modifier.isPublic(fieldModifiers)) {
+							paramList.add(field.getName() + " (" + field.getType().getSimpleName() + ")");
+						}
+					}
 
-				// List fields
-				Field[] fields = clazz.getDeclaredFields();
-				for (Field field : fields) {
-					paramList.add(field.getName() + " (" + field.getType().getSimpleName() + ")");
+					operationDetails.addProperty("params", String.join(", ", paramList));
+					producerDetailsList.add(operationDetails);
 				}
-
-				producersDetails.put("params", String.join(", ", paramList));
-
-				producersDetailsList.add(producersDetails);
+			} else {
+				JsonObject errorObject = new JsonObject();
+				errorObject.addProperty("error", "No files found in " + packagePath);
+				producerDetailsList.add(errorObject);
 			}
+
+		} catch (ClassNotFoundException e) {
+			JsonObject errorObject = new JsonObject();
+			errorObject.addProperty("error", e.getMessage());
+			producerDetailsList.add(errorObject);
 		}
 
-		return producersDetailsList.isEmpty()
-				? List.of(Map.of("message", "No producers found in package: " + Constants.PRODUCER_ROOT_PACKAGE))
-				: producersDetailsList;
+		return producerDetailsList.toString();
+
 	}
 }

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/ListProducerController.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/ListProducerController.java
@@ -1,10 +1,8 @@
 package ca.concordia.encs.citydata.core;
 
 import java.io.File;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
+import java.lang.reflect.Method;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -49,18 +47,9 @@ public class ListProducerController {
 					// Set class name
 					operationDetails.addProperty("name", clazz.getName());
 
-					// Collect fields and method signatures
-					List<String> paramList = new ArrayList<>();
-
-					// List fields
-					Field[] fields = clazz.getDeclaredFields();
-					for (Field field : fields) {
-						int fieldModifiers = field.getModifiers();
-						if (Modifier.isPublic(fieldModifiers)) {
-							paramList.add(field.getName() + " (" + field.getType().getSimpleName() + ")");
-						}
-					}
-
+					// List setter methods, which correspond to user-accessible params
+					Method[] methods = clazz.getMethods();
+					List<String> paramList = StringUtils.getParamDescriptions(methods);
 					operationDetails.addProperty("params", String.join(", ", paramList));
 					producerDetailsList.add(operationDetails);
 				}

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/ReflectionUtils.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/ReflectionUtils.java
@@ -33,7 +33,7 @@ public class ReflectionUtils {
 
 	public static Method findSetterMethod(Class<?> clazz, String paramName, JsonElement paramValue)
 			throws NoSuchMethodException {
-		String methodName = "set" + capitalize(paramName);
+		String methodName = "set" + StringUtils.capitalize(paramName);
 		for (Method method : clazz.getMethods()) {
 			if (method.getName().equals(methodName) && method.getParameterCount() == 1) {
 				return method;
@@ -57,7 +57,4 @@ public class ReflectionUtils {
 		return value.getAsString();
 	}
 
-	public static String capitalize(String str) {
-		return str == null || str.isEmpty() ? str : str.substring(0, 1).toUpperCase() + str.substring(1);
-	}
 }

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/StringUtils.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/StringUtils.java
@@ -1,0 +1,27 @@
+package ca.concordia.encs.citydata.core;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class StringUtils {
+
+	public static String capitalize(String str) {
+		return str == null || str.isEmpty() ? str : str.substring(0, 1).toUpperCase() + str.substring(1);
+	}
+
+	public static List<String> getParamDescriptions(Method[] methods) {
+		List<String> descriptions = new ArrayList<>();
+		for (Method method : methods) {
+			Parameter[] params = method.getParameters();
+			String methodName = method.getName();
+			if (methodName != "setMetadata" && methodName.startsWith("set") && params.length > 0) {
+				String paramName = method.getName().replace("set", "");
+				paramName = paramName.substring(0, 1).toLowerCase() + paramName.substring(1, paramName.length());
+				descriptions.add(paramName + " (" + params[0].getType().getSimpleName() + ")");
+			}
+		}
+		return descriptions;
+	}
+}

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/runners/SingleStepRunner.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/runners/SingleStepRunner.java
@@ -11,6 +11,7 @@ import ca.concordia.encs.citydata.core.IOperation;
 import ca.concordia.encs.citydata.core.IProducer;
 import ca.concordia.encs.citydata.core.IRunner;
 import ca.concordia.encs.citydata.core.ReflectionUtils;
+import ca.concordia.encs.citydata.core.StringUtils;
 import ca.concordia.encs.citydata.datastores.InMemoryDataStore;
 import ca.concordia.encs.citydata.producers.ExceptionProducer;
 
@@ -50,7 +51,7 @@ public class SingleStepRunner extends AbstractRunner implements IRunner {
 			// set Producer params
 			for (JsonElement param : this.targetProducerParams) {
 				final JsonObject paramObject = param.getAsJsonObject();
-				final String methodName = "set" + ReflectionUtils.capitalize(paramObject.get("name").getAsString());
+				final String methodName = "set" + StringUtils.capitalize(paramObject.get("name").getAsString());
 				for (Method method : targetProducerClass.getMethods()) {
 					if (method.getName().equals(methodName) && method.getParameterCount() == 1) {
 						final Object targetProducerParamValue = ReflectionUtils


### PR DESCRIPTION
**Problem:** 
The discovery routes (list producers, list operations) were not working in the server. However, the tests for these routes were passing, and the routes were working as expected in the developer computers. Summarized in #66 . 

**Details:** 
After debugging on the server, I found out the issue comes from the fact that the method `Thread.currentThread().getContextClassLoader().getResource(PATH_TO_PRODUCERS)` works differently when you run your code directly from the JAR vs. running via Maven/Eclipse. For example, it returns:

**Running in Eclipse**
`file:/Users/myusername/eclipse-workspace/ptidej/Middleware/target/classes/ca/concordia/encs/citydata/producers`

**Running java -jar in the server**
`jar:nested:/var/www/tools4citties-middleware/Middleware/target/Midleware-0.0.1-SNAPHSOT.jar/!BOOT-INF/classes/!/ca/concordia/encs/citydata/producers`

The path found in the server is clearly broken and cannot be used to find the folder and files.

**Solution:**
Get the project path using `Paths.get("").toAbsolutePath()`, then iterate the project folders until we find the Producer/Operation .java files. Caveat: This solution will work as soon as we install the middleware in a laptop/server along with all its Java files. If one simply copies/pastes the .jar into a server and tries to run it, the discovery routes will not work. Therefore, this is a temporary workaround while we cannot work on a more complete solution.

**Future work:**
In a coming PR, I will implement the [FileRepositoryFactory](https://github.com/ptidejteam/ptidej-Ptidej/blob/master/CPL/src/main/java/util/repository/impl/FileRepositoryFactory.java) from Ptidej into CityData. This way, we will be able to determine the project path at all times, no matter if we run from the file system or from a .jar file.




