### PR TITLE
Issue #80: Adding the  DatastoreManager implementation + tests

### DIFF
--- a/Middleware/.gitignore
+++ b/Middleware/.gitignore
@@ -49,3 +49,5 @@ build/
 !**/src/main/**/target/
 !**/src/test/**
 
+## Ignore JWT certs/keys
+Middleware/src/main/resources/certs/

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/contracts/IDatastoreManager.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/contracts/IDatastoreManager.java
@@ -1,0 +1,33 @@
+package ca.concordia.encs.citydata.core.contracts;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+*
+* CityData datastores interface to orchestrate all datastores.
+* 
+* @author Minette Zongo
+* @since 2025-08-19
+* 
+*/
+
+public interface IDatastoreManager {
+	
+    enum DatastoreType {
+        IN_MEMORY,
+        DISK,
+        MONGODB
+    }
+
+    void registerStores();
+
+    <T> IDataStore<T> getStore(DatastoreType type);
+
+    Map<DatastoreType, IDataStore<?>> getStores();
+
+    default boolean hasStore(DatastoreType type) {
+        return getStores().containsKey(type);
+    }
+
+}

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/datastores/DatastoreManager.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/datastores/DatastoreManager.java
@@ -7,6 +7,16 @@ import java.util.Map;
 import ca.concordia.encs.citydata.core.contracts.IDataStore;
 import ca.concordia.encs.citydata.core.contracts.IDatastoreManager;
 
+/**
+*
+* CityData datastores manager: a singleton implementation of IDatastoreManager that orchestrates all datastores.
+* 
+* @author Minette Zongo
+* @since 2025-08-19
+* 
+*/
+
+
 public class DatastoreManager implements IDatastoreManager {
 	private final Map<DatastoreType, IDataStore<?>> stores = new EnumMap<>(DatastoreType.class);
 

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/datastores/DatastoreManager.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/datastores/DatastoreManager.java
@@ -1,0 +1,49 @@
+package ca.concordia.encs.citydata.datastores;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+import ca.concordia.encs.citydata.core.contracts.IDataStore;
+import ca.concordia.encs.citydata.core.contracts.IDatastoreManager;
+
+public class DatastoreManager implements IDatastoreManager {
+	private final Map<DatastoreType, IDataStore<?>> stores = new EnumMap<>(DatastoreType.class);
+
+    private static final DatastoreManager instance = new DatastoreManager();
+
+    private DatastoreManager() {
+        registerStores();
+    }
+
+    public static DatastoreManager getInstance() {
+        return instance;
+    }
+
+    @Override
+    public void registerStores() {
+        stores.put(DatastoreType.IN_MEMORY, InMemoryDataStore.getInstance());
+        stores.put(DatastoreType.DISK, DiskDatastore.getInstance());
+        stores.put(DatastoreType.MONGODB, MongoDataStore.getInstance());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> IDataStore<T> getStore(DatastoreType type) {
+        if (type == null) {
+            throw new IllegalArgumentException("Datastore type cannot be null");
+        }
+        IDataStore<?> dataStore = stores.get(type);
+        if (dataStore == null) {
+            throw new IllegalArgumentException("No datastore registered for: " + type);
+        }
+        return (IDataStore<T>) dataStore;
+    }
+
+    @Override
+    public Map<DatastoreType, IDataStore<?>> getStores() {
+        return Collections.unmodifiableMap(stores);
+    }
+	
+
+}

--- a/Middleware/src/test/java/ca/concordia/encs/citydata/core/DatastoreManagerTest.java
+++ b/Middleware/src/test/java/ca/concordia/encs/citydata/core/DatastoreManagerTest.java
@@ -1,0 +1,137 @@
+package ca.concordia.encs.citydata.core;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import ca.concordia.encs.citydata.PayloadFactory;
+import ca.concordia.encs.citydata.TestTokenGenerator;
+
+import ca.concordia.encs.citydata.core.configs.AppConfig;
+import ca.concordia.encs.citydata.datastores.DatastoreManager;
+import ca.concordia.encs.citydata.core.contracts.IDatastoreManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.Matchers.*;
+
+@SpringBootTest(classes = AppConfig.class)
+@AutoConfigureMockMvc
+@ComponentScan(basePackages = "ca.concordia.encs.citydata.core")
+public class DatastoreManagerTest extends TestTokenGenerator {
+	
+	@Autowired
+	private MockMvc mockMvc;
+
+    private DatastoreManager datastoreManager;
+
+    @BeforeEach
+    void setUp() {
+        datastoreManager = DatastoreManager.getInstance();
+    }
+
+    /**
+     * Test that all required datastores exist and are registered
+     */
+    @Test
+    public void testDatastoresExist() {
+        // Test IN_MEMORY datastore exists
+        assertTrue(datastoreManager.hasStore(IDatastoreManager.DatastoreType.IN_MEMORY),
+                "IN_MEMORY datastore should exist");
+
+        // Test DISK datastore exists
+        assertTrue(datastoreManager.hasStore(IDatastoreManager.DatastoreType.DISK),
+                "DISK datastore should exist");
+
+        // Test MONGODB datastore exists
+        assertTrue(datastoreManager.hasStore(IDatastoreManager.DatastoreType.MONGODB),
+                "MONGODB datastore should exist");
+
+        // Verify all datastores are properly initialized
+        assertNotNull(datastoreManager.getStore(IDatastoreManager.DatastoreType.IN_MEMORY),
+                "IN_MEMORY datastore should be initialized");
+        assertNotNull(datastoreManager.getStore(IDatastoreManager.DatastoreType.DISK),
+                "DISK datastore should be initialized");
+        assertNotNull(datastoreManager.getStore(IDatastoreManager.DatastoreType.MONGODB),
+                "MONGODB datastore should be initialized");
+    }
+
+    /**
+     * Test datastore management via API endpoint using example query
+     * This tests if datastores are manageable through the API
+     */
+    @Test
+    public void testDatastoreManageableViaAPI() throws Exception {
+        // Use getExampleQuery to load a specific query from a JSON file
+        String jsonPayload = PayloadFactory.getExampleQuery("stringProducerRandom");
+
+        // Execute the request and verify response
+        MvcResult syncResult = mockMvc
+                .perform(post("/apply/sync")
+                        .header("Authorization", "Bearer " + getToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // Get the response content
+        String resultJson = syncResult.getResponse().getContentAsString();
+        
+        // Verify the response is not empty and doesn't contain error messages
+        assertNotNull(resultJson, "Response should not be null");
+        assertFalse(resultJson.isEmpty(), "Response should not be empty");
+        assertFalse(resultJson.contains("An error occurred"), "Response should not contain error messages");
+        assertFalse(resultJson.contains("Exception"), "Response should not contain exceptions");
+        
+        // Print the result for debugging (optional)
+        System.out.println("API Response: " + resultJson);
+    }
+
+    /**
+     * Test with basic query to ensure datastore interaction works
+     */
+    @Test
+    public void testBasicQueryDatastoreInteraction() throws Exception {
+        // Use basic query from PayloadFactory
+        String jsonPayload = PayloadFactory.getBasicQuery();
+
+        MvcResult syncResult = mockMvc
+                .perform(post("/apply/sync")
+                        .header("Authorization", "Bearer " + getToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String resultJson = syncResult.getResponse().getContentAsString();
+        
+        // Basic validation of response
+        assertNotNull(resultJson, "Response should not be null");
+        assertFalse(resultJson.isEmpty(), "Response should not be empty");
+        
+        // The response should be the result from the producer stored in InMemoryDataStore
+        System.out.println("Basic Query Response: " + resultJson);
+    }
+
+    /**
+     * Test error handling with invalid JSON
+     */
+    @Test
+    public void testInvalidJsonHandling() throws Exception {
+        String invalidJson = PayloadFactory.getInvalidJson();
+
+        mockMvc.perform(post("/apply/sync")
+                .header("Authorization", "Bearer " + getToken())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(containsString("not a valid JSON file")));
+    }
+}

--- a/Middleware/src/test/java/ca/concordia/encs/citydata/core/DatastoreManagerTest.java
+++ b/Middleware/src/test/java/ca/concordia/encs/citydata/core/DatastoreManagerTest.java
@@ -22,6 +22,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.hamcrest.Matchers.*;
 
+/**
+* DatastoreManager test to check existing datastores.
+* @author Minette Zongo
+* @since 2025-08-19
+*/
+
 @SpringBootTest(classes = AppConfig.class)
 @AutoConfigureMockMvc
 @ComponentScan(basePackages = "ca.concordia.encs.citydata.core")
@@ -29,7 +35,6 @@ public class DatastoreManagerTest extends TestTokenGenerator {
 	
 	@Autowired
 	private MockMvc mockMvc;
-
     private DatastoreManager datastoreManager;
 
     @BeforeEach
@@ -37,101 +42,22 @@ public class DatastoreManagerTest extends TestTokenGenerator {
         datastoreManager = DatastoreManager.getInstance();
     }
 
-    /**
-     * Test that all required datastores exist and are registered
-     */
     @Test
     public void testDatastoresExist() {
-        // Test IN_MEMORY datastore exists
         assertTrue(datastoreManager.hasStore(IDatastoreManager.DatastoreType.IN_MEMORY),
                 "IN_MEMORY datastore should exist");
 
-        // Test DISK datastore exists
         assertTrue(datastoreManager.hasStore(IDatastoreManager.DatastoreType.DISK),
                 "DISK datastore should exist");
 
-        // Test MONGODB datastore exists
         assertTrue(datastoreManager.hasStore(IDatastoreManager.DatastoreType.MONGODB),
                 "MONGODB datastore should exist");
 
-        // Verify all datastores are properly initialized
         assertNotNull(datastoreManager.getStore(IDatastoreManager.DatastoreType.IN_MEMORY),
                 "IN_MEMORY datastore should be initialized");
         assertNotNull(datastoreManager.getStore(IDatastoreManager.DatastoreType.DISK),
                 "DISK datastore should be initialized");
         assertNotNull(datastoreManager.getStore(IDatastoreManager.DatastoreType.MONGODB),
                 "MONGODB datastore should be initialized");
-    }
-
-    /**
-     * Test datastore management via API endpoint using example query
-     * This tests if datastores are manageable through the API
-     */
-    @Test
-    public void testDatastoreManageableViaAPI() throws Exception {
-        // Use getExampleQuery to load a specific query from a JSON file
-        String jsonPayload = PayloadFactory.getExampleQuery("stringProducerRandom");
-
-        // Execute the request and verify response
-        MvcResult syncResult = mockMvc
-                .perform(post("/apply/sync")
-                        .header("Authorization", "Bearer " + getToken())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(jsonPayload))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        // Get the response content
-        String resultJson = syncResult.getResponse().getContentAsString();
-        
-        // Verify the response is not empty and doesn't contain error messages
-        assertNotNull(resultJson, "Response should not be null");
-        assertFalse(resultJson.isEmpty(), "Response should not be empty");
-        assertFalse(resultJson.contains("An error occurred"), "Response should not contain error messages");
-        assertFalse(resultJson.contains("Exception"), "Response should not contain exceptions");
-        
-        // Print the result for debugging (optional)
-        System.out.println("API Response: " + resultJson);
-    }
-
-    /**
-     * Test with basic query to ensure datastore interaction works
-     */
-    @Test
-    public void testBasicQueryDatastoreInteraction() throws Exception {
-        // Use basic query from PayloadFactory
-        String jsonPayload = PayloadFactory.getBasicQuery();
-
-        MvcResult syncResult = mockMvc
-                .perform(post("/apply/sync")
-                        .header("Authorization", "Bearer " + getToken())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(jsonPayload))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        String resultJson = syncResult.getResponse().getContentAsString();
-        
-        // Basic validation of response
-        assertNotNull(resultJson, "Response should not be null");
-        assertFalse(resultJson.isEmpty(), "Response should not be empty");
-        
-        // The response should be the result from the producer stored in InMemoryDataStore
-        System.out.println("Basic Query Response: " + resultJson);
-    }
-
-    /**
-     * Test error handling with invalid JSON
-     */
-    @Test
-    public void testInvalidJsonHandling() throws Exception {
-        String invalidJson = PayloadFactory.getInvalidJson();
-
-        mockMvc.perform(post("/apply/sync")
-                .header("Authorization", "Bearer " + getToken())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(invalidJson))
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(containsString("not a valid JSON file")));
-    }
+    }   
 }


### PR DESCRIPTION
- created an interface for datastoreManager which defines the contract for the datastoremanager
- created a datastoreManager which is a singleton implementation of IDatastoreManager
- created a test for DatastoreManager that verifies the datastoremanager functionality, and extends TestTokenGenerator to use JWT authentication for API calls