### PR TITLE
Fix paths so they can be resolved correctly inside the jar

### DIFF
--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/controllers/ListOperationsController.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/controllers/ListOperationsController.java
@@ -1,10 +1,12 @@
 package ca.concordia.encs.citydata.core.controllers;
 
-import java.io.File;
 import java.lang.reflect.Method;
-import java.nio.file.Paths;
 import java.util.List;
+import java.util.regex.Pattern;
 
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.RegexPatternTypeFilter;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,12 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
-import ca.concordia.encs.citydata.core.utils.Constants;
 import ca.concordia.encs.citydata.core.utils.StringUtils;
 
 /**
  * This class is to print all available operations and their characteristics
- * 
+ *
  * @author Sikandar Ejaz
  * @since 2025-06-02
  */
@@ -25,42 +26,30 @@ import ca.concordia.encs.citydata.core.utils.StringUtils;
 @RequestMapping("/operations")
 public class ListOperationsController {
 
+	private static final String OPERATIONS_BASE_PACKAGE = "ca.concordia.encs.citydata.operations";
+
 	@GetMapping("/list")
 	public String listOperations() {
 		final JsonArray operationDetailsList = new JsonArray();
-		// Get the path to the package
-		final String projectRootPath = Paths.get("").toAbsolutePath() + "/";
-		final String packagePath = projectRootPath + Constants.OPERATION_ROOT_PACKAGE;
 
 		try {
-			// Scan for class files in the package directory
-			final String fileExtension = ".java";
-			final File[] files = new File(packagePath).listFiles((dir, name) -> name.endsWith(fileExtension));
+			ClassPathScanningCandidateComponentProvider scanner =
+					new ClassPathScanningCandidateComponentProvider(false);
 
-			if (files != null) {
-				for (File file : files) {
-					// Remove .class extension
-					final String className = file.getName().replace(fileExtension, "");
+			scanner.addIncludeFilter(new RegexPatternTypeFilter(Pattern.compile(".*")));
 
-					// Load the class using reflection
-					final Class<?> clazz = Class.forName("ca.concordia.encs.citydata.operations." + className);
+			for (BeanDefinition bd : scanner.findCandidateComponents(OPERATIONS_BASE_PACKAGE)) {
+				final String className = bd.getBeanClassName();
+				final Class<?> clazz = Class.forName(className);
 
-					// Map to hold operation details
-					JsonObject operationDetails = new JsonObject();
+				final JsonObject operationDetails = new JsonObject();
+				operationDetails.addProperty("name", clazz.getName());
 
-					// Set class name
-					operationDetails.addProperty("name", clazz.getName());
+				final Method[] methods = clazz.getMethods();
+				final List<String> paramList = StringUtils.getParamDescriptions(methods);
+				operationDetails.addProperty("params", String.join(", ", paramList));
 
-					// List setter methods, which correspond to user-accessible params
-					final Method[] methods = clazz.getMethods();
-					final List<String> paramList = StringUtils.getParamDescriptions(methods);
-					operationDetails.addProperty("params", String.join(", ", paramList));
-					operationDetailsList.add(operationDetails);
-				}
-			} else {
-				final JsonObject errorObject = new JsonObject();
-				errorObject.addProperty("error", "No files found in " + packagePath);
-				operationDetailsList.add(errorObject);
+				operationDetailsList.add(operationDetails);
 			}
 
 		} catch (ClassNotFoundException e) {
@@ -70,6 +59,5 @@ public class ListOperationsController {
 		}
 
 		return operationDetailsList.toString();
-
 	}
 }

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/controllers/ListOperationsController.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/controllers/ListOperationsController.java
@@ -19,7 +19,7 @@ import ca.concordia.encs.citydata.core.utils.StringUtils;
 /**
  * This class is to print all available operations and their characteristics
  *
- * @author Sikandar Ejaz
+ * @author Sikandar Ejaz and Gabriel C. Ullmann
  * @since 2025-06-02
  */
 @RestController
@@ -33,6 +33,7 @@ public class ListOperationsController {
 		final JsonArray operationDetailsList = new JsonArray();
 
 		try {
+			// This scanner implementation works both on the filesystem and inside a JAR
 			ClassPathScanningCandidateComponentProvider scanner =
 					new ClassPathScanningCandidateComponentProvider(false);
 

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/controllers/ListProducerController.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/controllers/ListProducerController.java
@@ -1,12 +1,11 @@
 package ca.concordia.encs.citydata.core.controllers;
 
-import java.io.File;
 import java.lang.reflect.Method;
-import java.nio.file.Paths;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+import org.springframework.core.type.filter.RegexPatternTypeFilter;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,53 +13,48 @@ import org.springframework.web.bind.annotation.RestController;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
-import ca.concordia.encs.citydata.core.utils.Constants;
 import ca.concordia.encs.citydata.core.utils.StringUtils;
 
 /**
  * This class is to print all available producers and their characteristics
- * 
+ *
  * @author Sikandar Ejaz
  * @since 2025-06-02
  */
-
 @RestController
 @RequestMapping("/producers")
 public class ListProducerController {
 
+	private static final String PRODUCER_BASE_PACKAGE = "ca.concordia.encs.citydata.producers";
+
 	@GetMapping("/list")
 	public String listProducers() {
 		final JsonArray producerDetailsList = new JsonArray();
-		final String projectRootPath = Paths.get("").toAbsolutePath() + "/";
-
-		final Map<String, String> packagesToScan = new LinkedHashMap<>();
-		packagesToScan.put(projectRootPath + Constants.PRODUCER_ROOT_PACKAGE, "ca.concordia.encs.citydata.producers.");
-		packagesToScan.put(projectRootPath + Constants.PRODUCER_ROOT_PACKAGE + "base/",
-				"ca.concordia.encs.citydata.producers.base.");
 
 		try {
-			final String fileExtension = ".java";
+			// This scanner works both on the filesystem (IDE) and inside a JAR
+			ClassPathScanningCandidateComponentProvider scanner =
+					new ClassPathScanningCandidateComponentProvider(false);
 
-			for (Map.Entry<String, String> entry : packagesToScan.entrySet()) {
-				final String packagePath = entry.getKey();
-				final String classPrefix = entry.getValue();
+			// Accept every class — we just want them all; adjust the filter if you
+			// only want a specific supertype or annotation
+			scanner.addIncludeFilter(new RegexPatternTypeFilter(
+					java.util.regex.Pattern.compile(".*")));
 
-				final File[] files = new File(packagePath).listFiles((dir, name) -> name.endsWith(fileExtension));
+			for (org.springframework.beans.factory.config.BeanDefinition bd
+					: scanner.findCandidateComponents(PRODUCER_BASE_PACKAGE)) {
 
-				if (files != null) {
-					for (File file : files) {
-						final String className = file.getName().replace(fileExtension, "");
-						final Class<?> clazz = Class.forName(classPrefix + className);
+				final String className = bd.getBeanClassName();
+				final Class<?> clazz = Class.forName(className);
 
-						final JsonObject operationDetails = new JsonObject();
-						operationDetails.addProperty("name", clazz.getName());
+				final JsonObject operationDetails = new JsonObject();
+				operationDetails.addProperty("name", clazz.getName());
 
-						final Method[] methods = clazz.getMethods();
-						final List<String> paramList = StringUtils.getParamDescriptions(methods);
-						operationDetails.addProperty("params", String.join(", ", paramList));
-						producerDetailsList.add(operationDetails);
-					}
-				}
+				final Method[] methods = clazz.getMethods();
+				final List<String> paramList = StringUtils.getParamDescriptions(methods);
+				operationDetails.addProperty("params", String.join(", ", paramList));
+
+				producerDetailsList.add(operationDetails);
 			}
 
 		} catch (ClassNotFoundException e) {

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/controllers/ListProducerController.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/controllers/ListProducerController.java
@@ -18,7 +18,7 @@ import ca.concordia.encs.citydata.core.utils.StringUtils;
 /**
  * This class is to print all available producers and their characteristics
  *
- * @author Sikandar Ejaz
+ * @author Sikandar Ejaz and Gabriel C. Ullmann
  * @since 2025-06-02
  */
 @RestController
@@ -32,12 +32,10 @@ public class ListProducerController {
 		final JsonArray producerDetailsList = new JsonArray();
 
 		try {
-			// This scanner works both on the filesystem (IDE) and inside a JAR
+			// This scanner implementation works both on the filesystem and inside a JAR
 			ClassPathScanningCandidateComponentProvider scanner =
 					new ClassPathScanningCandidateComponentProvider(false);
 
-			// Accept every class — we just want them all; adjust the filter if you
-			// only want a specific supertype or annotation
 			scanner.addIncludeFilter(new RegexPatternTypeFilter(
 					java.util.regex.Pattern.compile(".*")));
 

--- a/Middleware/src/main/resources/application.properties
+++ b/Middleware/src/main/resources/application.properties
@@ -23,8 +23,8 @@ security.credentials.path=./src/main/resources/scripts/credentials/credentials.t
 security.default.username=citydata
 security.default.password=$2a$12$ywMGTafXWo1JtNF4k6gYieGpFsHWsR4ONjx5RdRT93TA/99hUqZEC
 
-# Server host
-server.servlet.context-path=/citydata
+# Server host. Use this property only if you want to serve the application on a subpath without a reverse proxy.
+#server.servlet.context-path=/citydata
 
 # Server port (8080 is the default from Spring)
 #server.port=8084


### PR DESCRIPTION
- **Problem 1:** While the code works in a developer machine (using an IDE), it doesn't work once the jar is compiled and deployed to a server or container. Inside a .jar file there are no File objects you can list because resources are ZIP entries. 
- **Solution 1:** We need to use the classpath/reflection approach instead. The cleanest solution for Spring Boot is to use the ClassPath scanning that Spring already provides via ClassPathScanningCandidateComponentProvider.

---

- **Problem 2:** The addition of the /citydata subpath in PR #198 to the application.properties partially fixes the webpages that were created for apply/sync, but breaks all the rest.
- **Solution 2:** rollback the change.